### PR TITLE
Fixes for compilation on ARCHER

### DIFF
--- a/config/archer.cmake
+++ b/config/archer.cmake
@@ -1,0 +1,14 @@
+# Thunder
+set(CMAKE_Fortran_COMPILER "ftn")
+
+set(USER_Fortran_FLAGS "-s real64")
+set(USER_Fortran_FLAGS_RELEASE "-O3 -hfp3")
+set(USER_Fortran_FLAGS_DEBUG "-O0 -g")
+
+#set(NETCDF_INCLUDE_DIR "/sw/squeeze-x64/netcdf_fortran-4.2-static-intel13/include")
+#set(NETCDF_LIB_1       "/sw/squeeze-x64/netcdf_fortran-4.2-static-intel13/lib/libnetcdff.a")
+#set(NETCDF_LIB_2       "/sw/squeeze-x64/netcdf-4.2-static/lib/libnetcdf.a")
+#set(HDF5_LIB_1         "/sw/squeeze-x64/hdf5-1.8.8-static/lib/libhdf5_hl.a")
+#set(HDF5_LIB_2         "/sw/squeeze-x64/hdf5-1.8.8-static/lib/libhdf5.a")
+#set(SZIP_LIB           "/sw/squeeze-x64/szip-2.1-static/lib/libsz.a")
+#set(LIBS ${NETCDF_LIB_1} ${NETCDF_LIB_2} ${HDF5_LIB_1} ${HDF5_LIB_2} ${SZIP_LIB} m z curl)

--- a/src/srfc.f90
+++ b/src/srfc.f90
@@ -687,7 +687,11 @@ contains
              Lstart  = L - 0.001*L
              Lend    = L + 0.001*L
 
-             fxdif   = ( (- zt(2) / Lstart * (log(zt(2) / z0h(i,j)) - psih(zt(2) / Lstart) + psih(z0h(i,j) / Lstart)) / (log(zt(2) / z0m(i,j)) - psim(zt(2) / Lstart) + psim(z0m(i,j) / Lstart)) ** 2.) - (-zt(2) / Lend * (log(zt(2) / z0h(i,j)) - psih(zt(2) / Lend) + psih(z0h(i,j) / Lend)) / (log(zt(2) / z0m(i,j)) - psim(zt(2) / Lend) + psim(z0m(i,j) / Lend)) ** 2.) ) / (Lstart - Lend)
+             fxdif   = (  (- zt(2) / Lstart * (log(zt(2) / z0h(i,j)) - psih(zt(2) / Lstart) + psih(z0h(i,j) / Lstart)) &
+                          / (log(zt(2) / z0m(i,j)) - psim(zt(2) / Lstart) + psim(z0m(i,j) / Lstart)) ** 2.) &
+                        - (-zt(2) / Lend * (log(zt(2) / z0h(i,j)) - psih(zt(2) / Lend) + psih(z0h(i,j) / Lend)) &
+                          / (log(zt(2) / z0m(i,j)) - psim(zt(2) / Lend) + psim(z0m(i,j) / Lend)) ** 2.) ) &
+                       / (Lstart - Lend)
 
              L       = L - fx / fxdif
 
@@ -730,7 +734,11 @@ contains
          fx      = Rib - zt(2) / L * (log(zt(2) / z0hav) - psih(zt(2) / L) + psih(z0hav / L)) / (log(zt(2) / z0mav) - psim(zt(2) / L) + psim(z0mav / L)) ** 2.
          Lstart  = L - 0.001*L
          Lend    = L + 0.001*L
-         fxdif   = ( (- zt(2) / Lstart * (log(zt(2) / z0hav) - psih(zt(2) / Lstart) + psih(z0hav / Lstart)) / (log(zt(2) / z0mav) - psim(zt(2) / Lstart) + psim(z0mav / Lstart)) ** 2.) - (-zt(2) / Lend * (log(zt(2) / z0hav) - psih(zt(2) / Lend) + psih(z0hav / Lend)) / (log(zt(2) / z0mav) - psim(zt(2) / Lend) + psim(z0mav / Lend)) ** 2.) ) / (Lstart - Lend)
+         fxdif   = (   (- zt(2) / Lstart * (log(zt(2) / z0hav) - psih(zt(2) / Lstart) + psih(z0hav / Lstart)) &
+                       / (log(zt(2) / z0mav) - psim(zt(2) / Lstart) + psim(z0mav / Lstart)) ** 2.) &
+                     - (-zt(2) / Lend * (log(zt(2) / z0hav) - psih(zt(2) / Lend) + psih(z0hav / Lend)) &
+                       / (log(zt(2) / z0mav) - psim(zt(2) / Lend) + psim(z0mav / Lend)) ** 2.) &
+                   ) / (Lstart - Lend)
          L       = L - fx / fxdif
          if(Rib * L < 0. .or. abs(L) == 1e5) then
             if(Rib > 0) L = 0.01
@@ -1074,16 +1082,33 @@ contains
           a_tsoil(k,i,j) = tsoilm(k,i,j) + rk3coef / pCs(k,i,j) * ( lambdah(k,i,j) * (a_tsoil(k+1,i,j) - a_tsoil(k,i,j)) / dzsoilh(k) - lambdah(k-1,i,j) * (a_tsoil(k,i,j) - a_tsoil(k-1,i,j)) / dzsoilh(k-1) ) / dzsoil(k)
         end do
 
-        a_tsoil(ksoilmax,i,j) = tsoilm(ksoilmax,i,j) + rk3coef / pCs(ksoilmax,i,j) * ( lambda(ksoilmax,i,j) * (tsoildeep(i,j) - a_tsoil(ksoilmax,i,j)) / dzsoil(ksoilmax) - lambdah(ksoilmax-1,i,j) * (a_tsoil(ksoilmax,i,j) - a_tsoil(ksoilmax-1,i,j)) / dzsoil(ksoilmax-1) ) / dzsoil(ksoilmax)
+        a_tsoil(ksoilmax,i,j) = tsoilm(ksoilmax,i,j) &
+           + rk3coef / pCs(ksoilmax,i,j) * ( &
+               lambda(ksoilmax,i,j) * (tsoildeep(i,j) &
+               - a_tsoil(ksoilmax,i,j)) / dzsoil(ksoilmax) &
+               - lambdah(ksoilmax-1,i,j) * (a_tsoil(ksoilmax,i,j) - a_tsoil(ksoilmax-1,i,j)) / dzsoil(ksoilmax-1) &
+             ) / dzsoil(ksoilmax)
 
         !" Solve the diffusion equation for the moisture transport (closed bottom for now)
         a_phiw(1,i,j) = phiwm(1,i,j) + rk3coef * ( lambdash(1,i,j) * (a_phiw(2,i,j) - a_phiw(1,i,j)) / dzsoilh(1) - gammash(1,i,j) - (phifrac(1,i,j) * LEveg + LEsoil) / (rowt*alvl)) / dzsoil(1)
 
         do k = 2, ksoilmax-1
-          a_phiw(k,i,j) = phiwm(k,i,j) + rk3coef * ( lambdash(k,i,j) * (a_phiw(k+1,i,j) - a_phiw(k,i,j)) / dzsoilh(k) - gammash(k,i,j) - lambdash(k-1,i,j) * (a_phiw(k,i,j) - a_phiw(k-1,i,j)) / dzsoilh(k-1) + gammash(k-1,i,j) - (phifrac(k,i,j) * LEveg) / (rowt*alvl)) / dzsoil(k)
+          a_phiw(k,i,j) = phiwm(k,i,j) &
+             + rk3coef * ( &
+               lambdash(k,i,j) * (a_phiw(k+1,i,j) - a_phiw(k,i,j)) / dzsoilh(k) &
+               - gammash(k,i,j) &
+               - lambdash(k-1,i,j) * (a_phiw(k,i,j) - a_phiw(k-1,i,j)) / dzsoilh(k-1) &
+               + gammash(k-1,i,j) &
+               - (phifrac(k,i,j) * LEveg) / (rowt*alvl) &
+             ) / dzsoil(k)
         end do
 
-        a_phiw(ksoilmax,i,j) = phiwm(ksoilmax,i,j) + rk3coef * (- lambdash(ksoilmax-1,i,j) * (a_phiw(ksoilmax,i,j) - a_phiw(ksoilmax-1,i,j)) / dzsoil(ksoilmax-1) + gammash(ksoilmax-1,i,j) - (phifrac(ksoilmax,i,j) * LEveg) / (rowt*alvl) ) / dzsoil(ksoilmax)
+        a_phiw(ksoilmax,i,j) = phiwm(ksoilmax,i,j) &
+           + rk3coef * ( &
+             - lambdash(ksoilmax-1,i,j) * (a_phiw(ksoilmax,i,j) - a_phiw(ksoilmax-1,i,j)) / dzsoil(ksoilmax-1) &
+             + gammash(ksoilmax-1,i,j) &
+             - (phifrac(ksoilmax,i,j) * LEveg) / (rowt*alvl) &
+           ) / dzsoil(ksoilmax)
 
       end do
     end do

--- a/src/stat.f90
+++ b/src/stat.f90
@@ -429,7 +429,9 @@ contains
   ! SUBROUTINE ACCUM_STAT: Accumulates various statistics over an
   ! averaging period for radiation variables
   !
-  subroutine accum_rad(n1,n2,n3,rflx,sflx,alb,lflxu,lflxd,sflxu,sflxd,lflxu_ca,lflxd_ca,sflxu_ca,sflxd_ca,sflxu_toa,sflxd_toa,lflxu_toa,lflxd_toa,sflxu_toa_ca,sflxd_toa_ca,lflxu_toa_ca,lflxd_toa_ca,dn0,dzt,pi0,pi1,sst,time_in,vapor,radtyp,a_pexnr,a_theta,CCN,cntlat)
+  subroutine accum_rad(n1,n2,n3,rflx,sflx,alb,lflxu,lflxd,sflxu,sflxd,lflxu_ca,lflxd_ca,sflxu_ca,sflxd_ca,sflxu_toa,&
+        sflxd_toa,lflxu_toa,lflxd_toa,sflxu_toa_ca,sflxd_toa_ca,lflxu_toa_ca,lflxd_toa_ca,dn0,dzt,pi0,pi1,sst,time_in,&
+        vapor,radtyp,a_pexnr,a_theta,CCN,cntlat)
     use radiation, only : d4stream
     integer, intent (in) :: n1,n2,n3
     real, intent (in)    :: rflx(n1,n2,n3)


### PR DESCRIPTION
[ARCHER](http://www.archer.ac.uk/) uses the Cray Fortran compiler which is more restrictive about line length than other compilers it seems. This commit splits the lines that were too long and adds a compilation configuration which works on ARCHER.