### PR TITLE
Bugfix: use valid reference time for netcdf output

### DIFF
--- a/src/ncio.f90
+++ b/src/ncio.f90
@@ -628,7 +628,7 @@ contains
        if (itype==2) ncinfo = 'tttt'
     case('time')
        if (itype==0) ncinfo = 'Time'
-       if (itype==1) ncinfo = 'seconds since 2000-00-00 0000'
+       if (itype==1) ncinfo = 'seconds since 2000-01-01 0000'
        if (itype==2) ncinfo = 'time'
     case('zt')
        if (itype==0) ncinfo = 'Vertical displacement of cell centers'


### PR DESCRIPTION
Previously the reference time was `` which is not a CF-compliant
reference time (since the month and day are 0) as can be seen with
`cftime`:

```
In [1]: import cftime

In [2]: cftime.num2date(0, "seconds since 2000-00-00 0000")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-e59b11e3233f> in <module>()
----> 1 cftime.num2date(0, "seconds since 2000-00-00 0000")

cftime/_cftime.pyx in cftime._cftime.num2date()

cftime/_cftime.pyx in cftime._cftime._dateparse()

ValueError: month must be in 1..12

In [3]: cftime.num2date(0, "seconds since 2000-01-01 0000")
Out[3]: datetime.datetime(2000, 1, 1, 0, 0)
```

This causes e.g. `xarray` and other packages to fail to interpret the
time coordinate correctly.